### PR TITLE
Change project URL for the Solid Elections team

### DIFF
--- a/public/editions/2020/projects.json
+++ b/public/editions/2020/projects.json
@@ -312,7 +312,7 @@
       ],
       "coaches": ["af22a4aa-b313-4892-be6f-be3587d61943", "7ce8c02f-f957-407d-ac15-50ff89acc522"]
     },
-    "repository": "https://github.com/osoc20/sep_frontend",
+    "repository": "https://osoc20.github.io/simplification-election-procedures/",
     "website": null,
     "partners": ["abb"]
   },


### PR DESCRIPTION
We have three separate repositories (declaration frontend, end-user frontend and API), so I changed the URL to our landing page which links all three repositories. (Also the old link was for an old hackathon project)