### PR TITLE
perf: use Next's built in Image component for optimization

### DIFF
--- a/assets/scss/_headshots.scss
+++ b/assets/scss/_headshots.scss
@@ -14,15 +14,10 @@ i.fas {
   margin-bottom: 2.6rem;
 
   .headshot-detail__wrapper {
-    width: 100%;
     position: relative;
-    padding-bottom: 100%;
     margin-bottom: 1rem;
+    width: 100%;
     img {
-      object-fit: cover;
-      position: absolute;
-      top: 0;
-      left: 0;
       border-radius: 50%;
       height: 100%;
       width: 100%;

--- a/components/Editions/Headshot.jsx
+++ b/components/Editions/Headshot.jsx
@@ -9,7 +9,7 @@ const HeadShot = ({ data, socials, picture, roleShown }) => {
   return (
     <article className="small-10 medium-4 large-3 cell headshot-detail">
       <div className="headshot-detail__wrapper">
-        <Image layout="fill" src={picture} alt={name} />
+        <Image layout="intrinsic" width="400" height="400" src={picture} alt={name} />
       </div>
       <h2 className="h4 headshot-detail__name">{name}</h2>
       {roleShown && (isCoach ? <p>Coach</p> : <p>Student</p>)}

--- a/components/Editions/Headshot.jsx
+++ b/components/Editions/Headshot.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import Image from 'next/image';
 import ExternalLink from '../UI/ExternalLink';
 
 const HeadShot = ({ data, socials, picture, roleShown }) => {
@@ -8,7 +9,7 @@ const HeadShot = ({ data, socials, picture, roleShown }) => {
   return (
     <article className="small-10 medium-4 large-3 cell headshot-detail">
       <div className="headshot-detail__wrapper">
-        <img src={picture} alt={name} />
+        <Image layout="fill" src={picture} alt={name} />
       </div>
       <h2 className="h4 headshot-detail__name">{name}</h2>
       {roleShown && (isCoach ? <p>Coach</p> : <p>Student</p>)}

--- a/components/Editions/Project.jsx
+++ b/components/Editions/Project.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
-import Image from 'next/image';
 import { ButtonLink } from '../UI/Buttons';
 
 const BREAKOUT_UNSTARTED = 1;
@@ -44,14 +43,14 @@ const Project = ({ edition, project, isDemoDay }) => {
       const minutes = start.getMinutes();
       $buttonContent = (
         <>
-          <Image layout="fill" className="c-icon" src="/img/icons/time.svg" alt="clock" />
+          <img className="c-icon" src="/img/icons/time.svg" alt="clock" />
           Meet us at {hours}:{minutes === 0 ? '00' : minutes}
         </>
       );
     } else if (breakoutStatus === BREAKOUT_IN_PROGRESS) {
       $buttonContent = (
         <>
-          <Image layout="fill" className="c-icon" src="/img/icons/video.svg" alt="video" />
+          <img className="c-icon" src="/img/icons/video.svg" alt="video" />
           Meet the team
         </>
       );
@@ -59,7 +58,7 @@ const Project = ({ edition, project, isDemoDay }) => {
     } else if (breakoutStatus === BREAKOUT_ENDED) {
       $buttonContent = (
         <>
-          <Image layout="fill" className="c-icon" src="/img/icons/time.svg" alt="clock" />
+          <img className="c-icon" src="/img/icons/time.svg" alt="clock" />
           Session has ended
         </>
       );

--- a/components/Editions/Project.jsx
+++ b/components/Editions/Project.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
+import Image from 'next/image';
 import { ButtonLink } from '../UI/Buttons';
 
 const BREAKOUT_UNSTARTED = 1;
@@ -43,14 +44,14 @@ const Project = ({ edition, project, isDemoDay }) => {
       const minutes = start.getMinutes();
       $buttonContent = (
         <>
-          <img className="c-icon" src="/img/icons/time.svg" alt="clock" />
+          <Image layout="fill" className="c-icon" src="/img/icons/time.svg" alt="clock" />
           Meet us at {hours}:{minutes === 0 ? '00' : minutes}
         </>
       );
     } else if (breakoutStatus === BREAKOUT_IN_PROGRESS) {
       $buttonContent = (
         <>
-          <img className="c-icon" src="/img/icons/video.svg" alt="video" />
+          <Image layout="fill" className="c-icon" src="/img/icons/video.svg" alt="video" />
           Meet the team
         </>
       );
@@ -58,7 +59,7 @@ const Project = ({ edition, project, isDemoDay }) => {
     } else if (breakoutStatus === BREAKOUT_ENDED) {
       $buttonContent = (
         <>
-          <img className="c-icon" src="/img/icons/time.svg" alt="clock" />
+          <Image layout="fill" className="c-icon" src="/img/icons/time.svg" alt="clock" />
           Session has ended
         </>
       );


### PR DESCRIPTION
Next's built in Image component lazy loads image by default, so images not in the viewport will not have an effect on page load time.

closes #140 