### PR TITLE
fix: last year's projects showcase

### DIFF
--- a/assets/scss/_template-detail.scss
+++ b/assets/scss/_template-detail.scss
@@ -104,6 +104,10 @@
   gap: 4rem 2rem;
 }
 
+.c-projects-content {
+  margin-top: 1.5rem;
+}
+
 .c-projects-project {
   max-width: 600px;
   opacity: 0.9;

--- a/public/editions/2020/projects.json
+++ b/public/editions/2020/projects.json
@@ -73,7 +73,8 @@
       "startsAt": "July 30, 2020 15:00:00",
       "endsAt": "July 30, 2020 15:15:00",
       "room": "https://meet.openknowledge.be/11"
-    }
+    },
+    "featured": true
   },
   {
     "id": "bit-of-trust",
@@ -121,7 +122,8 @@
       "startsAt": "July 30, 2020 14:30:00",
       "endsAt": "July 30, 2020 14:45:00",
       "room": "https://meet.openknowledge.be/1"
-    }
+    },
+    "featured": true
   },
   {
     "id": "better-bike-brussels",
@@ -283,7 +285,8 @@
       "startsAt": "July 30, 2020 15:15:00",
       "endsAt": "July 30, 2020 15:30:00",
       "room": "https://meet.openknowledge.be/15"
-    }
+    },
+    "featured": true
   },
   {
     "id": "destination-insight",
@@ -426,7 +429,8 @@
       "startsAt": "July 30, 2020 14:45:00",
       "endsAt": "July 30, 2020 15:00:00",
       "room": "https://meet.openknowledge.be/6"
-    }
+    },
+    "featured": true
   },
   {
     "id": "get-engaged",


### PR DESCRIPTION
This section just wasn't showing because we hadn't marked any of last year's projects as `featured` in the json data.

Closes #142 